### PR TITLE
Start using httpclientfactory to get shared client

### DIFF
--- a/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
+++ b/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.Security.CAS" Version="2.0.4" />
-    <PackageReference Include="ietws" Version="0.1.30" />
+    <PackageReference Include="ietws" Version="0.1.33" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />

--- a/src/PeopleLookup.Mvc/Services/IdentityService.cs
+++ b/src/PeopleLookup.Mvc/Services/IdentityService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Ietws;
 using Microsoft.Extensions.Options;
@@ -21,10 +22,10 @@ namespace PeopleLookup.Mvc.Services
     {
         private readonly AuthSettings _authSettings;
         private readonly IetClient _clientws;
-        public IdentityService(IOptions<AuthSettings> authSettings)
+        public IdentityService(IOptions<AuthSettings> authSettings, HttpClient httpClient)
         {
             _authSettings = authSettings.Value;
-            _clientws = new IetClient(_authSettings.IamKey);
+            _clientws = new IetClient(httpClient, _authSettings.IamKey);
         }
 
         public async Task<SearchResult> Lookup(string search)

--- a/src/PeopleLookup.Mvc/Services/IdentityService.cs
+++ b/src/PeopleLookup.Mvc/Services/IdentityService.cs
@@ -22,8 +22,10 @@ namespace PeopleLookup.Mvc.Services
     {
         private readonly AuthSettings _authSettings;
         private readonly IetClient _clientws;
-        public IdentityService(IOptions<AuthSettings> authSettings, HttpClient httpClient)
+        public IdentityService(IOptions<AuthSettings> authSettings, IHttpClientFactory httpClientFactory)
         {
+            var httpClient = httpClientFactory.CreateClient("identity");
+
             _authSettings = authSettings.Value;
             _clientws = new IetClient(httpClient, _authSettings.IamKey);
         }

--- a/src/PeopleLookup.Mvc/Startup.cs
+++ b/src/PeopleLookup.Mvc/Startup.cs
@@ -38,6 +38,7 @@ namespace PeopleLookup.Mvc
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
+            services.AddHttpClient<IIdentityService, IdentityService>();
             services.AddScoped<IIdentityService, IdentityService>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddScoped<IPermissionService, PermissionService>();

--- a/src/PeopleLookup.Mvc/Startup.cs
+++ b/src/PeopleLookup.Mvc/Startup.cs
@@ -38,7 +38,7 @@ namespace PeopleLookup.Mvc
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            services.AddHttpClient<IIdentityService, IdentityService>();
+            services.AddHttpClient("identity");
             services.AddScoped<IIdentityService, IdentityService>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddScoped<IPermissionService, PermissionService>();


### PR DESCRIPTION
Might help with the whole azure IETWS query issues -- using a httpclientfactory might do a better job sharing connections.  Even if it doesn't help it might be a better way for us to go in the future.  

@jSylvestre something to look at next year