### PR TITLE
Jcs/fix errors

### DIFF
--- a/src/PeopleLookup.Mvc/Controllers/HomeController.cs
+++ b/src/PeopleLookup.Mvc/Controllers/HomeController.cs
@@ -14,6 +14,7 @@ namespace PeopleLookup.Mvc.Controllers
     {
         private readonly IIdentityService _identityService;
         private readonly IPermissionService _permissionService;
+        const int BatchSize = 20;
 
         public HomeController(IIdentityService identityService, IPermissionService permissionService)
         {
@@ -64,10 +65,21 @@ namespace PeopleLookup.Mvc.Controllers
                 matches = System.Text.RegularExpressions.Regex.Matches(model.BulkEmail, regexEmailPattern,
                         System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
-                var results = matches.Select(a => _identityService.Lookup(a.ToString())).ToArray();
+                var results = new List<SearchResult>();
+                var batches = matches.Select(m => m.ToString())
+                    .Select((value, index) => new { value, index })
+                    .GroupBy(x => x.index / BatchSize) // Process 20 at a time
+                    .Select(g => g.Select(x => x.value).ToList());
 
-                var tempResults = await Task.WhenAll(results);
-                foreach (var tempResult in tempResults)
+                foreach (var batch in batches)
+                {
+                    var batchResults = await Task.WhenAll(
+                        batch.Select(item => _identityService.Lookup(item))
+                    );
+                    results.AddRange(batchResults);
+                }
+
+                foreach (var tempResult in results)
                 {
                     //I could change this to AddRange if I move the AllowSensitive to the lookup service and change it to a List from IList.
                     if (!allowSensitiveInfo)
@@ -82,9 +94,22 @@ namespace PeopleLookup.Mvc.Controllers
             {
                 matches = System.Text.RegularExpressions.Regex.Matches(model.BulkKerb, regexKerbPattern,
                     System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-                var results = matches.Select(a => _identityService.Lookup(a.ToString())).ToArray();
-                var tempResults = await Task.WhenAll(results);
-                foreach (var tempResult in tempResults)
+
+                var results = new List<SearchResult>();
+                var batches = matches.Select(m => m.ToString())
+                    .Select((value, index) => new { value, index })
+                    .GroupBy(x => x.index / BatchSize) // Process 20 at a time
+                    .Select(g => g.Select(x => x.value).ToList());
+
+                foreach (var batch in batches)
+                {
+                    var batchResults = await Task.WhenAll(
+                        batch.Select(item => _identityService.Lookup(item))
+                    );
+                    results.AddRange(batchResults);
+                }
+
+                foreach (var tempResult in results)
                 {
                     //I could change this to AddRange if I move the AllowSensitive to the lookup service and change it to a List from IList.
                     if (!allowSensitiveInfo)
@@ -99,9 +124,22 @@ namespace PeopleLookup.Mvc.Controllers
             {
                 matches = System.Text.RegularExpressions.Regex.Matches(model.BulkIamIds, regexIamIdPattern,
                     System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-                var results = matches.Select(a => _identityService.LookupId(PeopleSearchField.iamId,a.ToString())).ToArray();
-                var tempResults = await Task.WhenAll(results);
-                foreach (var tempResult in tempResults)
+
+                var results = new List<SearchResult>();
+                var batches = matches.Select(m => m.ToString())
+                    .Select((value, index) => new { value, index })
+                    .GroupBy(x => x.index / BatchSize) // Process 20 at a time
+                    .Select(g => g.Select(x => x.value).ToList());
+
+                foreach (var batch in batches)
+                {
+                    var batchResults = await Task.WhenAll(
+                        batch.Select(item => _identityService.LookupId(PeopleSearchField.iamId, item))
+                    );
+                    results.AddRange(batchResults);
+                }
+
+                foreach (var tempResult in results)
                 {
                     //I could change this to AddRange if I move the AllowSensitive to the lookup service and change it to a List from IList.
                     if (!allowSensitiveInfo) //Was missing?
@@ -155,9 +193,21 @@ namespace PeopleLookup.Mvc.Controllers
                     matches = System.Text.RegularExpressions.Regex.Matches(model.BulkStudentIds, regexStudentIdPattern,
                         System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
-                    var results = matches.Select(a => _identityService.LookupId(PeopleSearchField.studentId, a.ToString())).ToArray();
-                    var tempResults = await Task.WhenAll(results);
-                    foreach (var tempResult in tempResults)
+                    var results = new List<SearchResult>();
+                    var batches = matches.Select(m => m.ToString())
+                        .Select((value, index) => new { value, index })
+                        .GroupBy(x => x.index / BatchSize) // Process 20 at a time
+                        .Select(g => g.Select(x => x.value).ToList());
+
+                    foreach (var batch in batches)
+                    {
+                        var batchResults = await Task.WhenAll(
+                            batch.Select(item => _identityService.LookupId(PeopleSearchField.studentId, item))
+                        );
+                        results.AddRange(batchResults);
+                    }
+
+                    foreach (var tempResult in results)
                     {
                         model.Results.Add(tempResult);
                     }
@@ -181,9 +231,21 @@ namespace PeopleLookup.Mvc.Controllers
                     matches = System.Text.RegularExpressions.Regex.Matches(model.BulkEmployeeId, regexEmpIdPattern,
                         System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
-                    var results = matches.Select(a => _identityService.LookupId(PeopleSearchField.employeeId, a.ToString())).ToArray();
-                    var tempResults = await Task.WhenAll(results);
-                    foreach (var tempResult in tempResults)
+                    var results = new List<SearchResult>();
+                    var batches = matches.Select(m => m.ToString())
+                        .Select((value, index) => new { value, index })
+                        .GroupBy(x => x.index / BatchSize) // Process 20 at a time
+                        .Select(g => g.Select(x => x.value).ToList());
+
+                    foreach (var batch in batches)
+                    {
+                        var batchResults = await Task.WhenAll(
+                            batch.Select(item => _identityService.LookupId(PeopleSearchField.employeeId, item))
+                        );
+                        results.AddRange(batchResults);
+                    }
+
+                    foreach (var tempResult in results)
                     {
                         model.Results.Add(tempResult);
                     }

--- a/src/PeopleLookup.Mvc/Services/IdentityService.cs
+++ b/src/PeopleLookup.Mvc/Services/IdentityService.cs
@@ -362,6 +362,13 @@ namespace PeopleLookup.Mvc.Services
 
             if (ucdKerbResult.ResponseData.Results.Length != 1)
             {
+                //foreach (var res in ucdKerbResult.ResponseData.Results)
+                //{
+                //    var jsonString = System.Text.Json.JsonSerializer.Serialize(res, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+                //    System.Diagnostics.Debug.WriteLine(jsonString);
+                //}
+
+
                 var iamIds = ucdKerbResult.ResponseData.Results.Select(a => a.IamId).Distinct().ToArray();
                 var userIDs = ucdKerbResult.ResponseData.Results.Select(a => a.UserId).Distinct().ToArray();
                 if (iamIds.Length != 1 && userIDs.Length != 1)
@@ -374,7 +381,11 @@ namespace PeopleLookup.Mvc.Services
 
             var ucdKerbPerson = ucdKerbResult.ResponseData.Results.First();
             var personResults = await _clientws.People.Get(ucdKerbPerson.IamId);
-            if(personResults.ResponseData.Results.Length != 1)
+
+            //Sometimes, this was returning multiple identical results. So we need to check for that.
+            var uniquePersonResultCount = personResults.ResponseData.Results.Select(a => System.Text.Json.JsonSerializer.Serialize(a)).Distinct().ToArray().Length;
+
+            if (uniquePersonResultCount != 1)
             {
                 searchResult.ErrorMessage =
                     $"IAM issue with non unique values for IAM Id: {ucdKerbPerson.IamId}";


### PR DESCRIPTION
Issue #63 

Exception:
(Lookup) Error: An error occurred while sending the request. Inner: The response ended prematurely. System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.IO.IOException: The response ended prematurely. at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken) --- End of inner exception stack trace --- at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken) at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken) at System.Net.Http.DiagnosticsHandler.SendAsyncCore(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken) at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken) at Microsoft.Extensions.Http.Logging.LoggingHttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) at Microsoft.Extensions.Http.Logging.LoggingScopeHttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken) at Ietws.RequestBase.GetAsync at Ietws.PeopleRequests.Get(String iamId) at PeopleLookup.Mvc.Services.IdentityService.LookupEmail(String email) in C:\GitProjects\people-lookup\src\PeopleLookup.Mvc\Services\IdentityService.cs:line 342 at PeopleLookup.Mvc.Services.IdentityService.Lookup(String search) in C:\GitProjects\people-lookup\src\PeopleLookup.Mvc\Services\IdentityService.cs:line 42