### PR TITLE
Adds Polly for resilience to transient errors

### DIFF
--- a/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
+++ b/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
@@ -13,7 +13,9 @@
   <ItemGroup>
     <PackageReference Include="ietws" Version="0.2.26" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.16" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
+		<PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Implements Polly retry and circuit breaker policies to handle transient HTTP errors and IO exceptions when calling the identity service. This improves the application's resilience and prevents cascading failures. Configures an HttpClient with connection pooling for improved performance.