### PR TITLE
Improves Identity Service resilience and accuracy.

### DIFF
--- a/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
+++ b/src/PeopleLookup.Mvc/PeopleLookup.Mvc.csproj
@@ -12,8 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="ietws" Version="0.2.26" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.16" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
+	  <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.16" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1" />
+	  <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
+	  <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/PeopleLookup.Mvc/Services/IdentityService.cs
+++ b/src/PeopleLookup.Mvc/Services/IdentityService.cs
@@ -374,7 +374,10 @@ namespace PeopleLookup.Mvc.Services
 
             var ucdKerbPerson = ucdKerbResult.ResponseData.Results.First();
             var personResults = await _clientws.People.Get(ucdKerbPerson.IamId);
-            if(personResults.ResponseData.Results.Length != 1)
+            //Sometimes, this was returning multiple identical results. So we need to check for that.
+            var uniquePersonResultCount = personResults.ResponseData.Results.Select(a => System.Text.Json.JsonSerializer.Serialize(a)).Distinct().ToArray().Length;
+
+            if (uniquePersonResultCount != 1)
             {
                 searchResult.ErrorMessage =
                     $"IAM issue with non unique values for IAM Id: {ucdKerbPerson.IamId}";


### PR DESCRIPTION
Adds Polly retry and circuit breaker policies to the Identity Service's HTTP client to improve resilience against transient errors and availability issues. This prevents cascading failures and improves overall stability.

Also, this commit addresses an issue where the identity service would occasionally return multiple identical person results. The logic is updated to ensure that only unique person results are considered, preventing errors when a unique result is expected.

Closes #63 